### PR TITLE
fix(activation): resolve no-KG memory contradiction + name the memory store (v1.4.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "source": "./claude-code",
       "description": "Persistent memory, RAG/context discipline, critical-thinking heuristics, and interaction unit-testing as Claude Code skills.",
       "displayName": "Agentic Rules Framework",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "author": {
         "name": "Paulus Ery Wasito Adhi",
         "email": "paupawsan@users.noreply.github.com"

--- a/bootstrap.json
+++ b/bootstrap.json
@@ -5,7 +5,7 @@
     "license_file": "LICENSE"
   },
   "agentic_bootstrap": {
-    "version": "1.4.1",
+    "version": "1.4.2",
     "framework_id": "agentic-core-rules-v1",
     "agent_algorithm_reference": "Bootstrap.md",
     "distributed_integration": true,

--- a/claude-code/.claude-plugin/plugin.json
+++ b/claude-code/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schemastore.org/claude-code-plugin-manifest.json",
   "name": "agentic-rules",
   "displayName": "Agentic Rules Framework",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Structured behavioral rules for AI agents: persistent memory, RAG/context discipline, critical-thinking heuristics, and interaction unit-testing. Delivered as auto-invocable skills, with an optional always-on injector and a Knowledge Graph MCP server.",
   "author": {
     "name": "Paulus Ery Wasito Adhi",

--- a/claude-code/hooks/session-start.py
+++ b/claude-code/hooks/session-start.py
@@ -29,64 +29,82 @@ TRUE_VALUES = {"true", "1", "yes", "on"}
 # on their own they read as optional background and the model defaults to its
 # native behavior (ad-hoc memory, no KG). This preamble is the binding contract:
 # it names the concrete behaviors that must change and how the KG degrades.
-_PREAMBLE_HEAD = (
-    "# Project operating procedure — Agentic Rules Framework\n\n"
-    "This project has opted into the rules below by installing and enabling this "
-    "plugin. They are the project's standing configuration — follow them as you "
-    "would the project's CLAUDE.md, with the same authority as a direct user "
-    "instruction. They are not optional background, and you do not need to ask "
-    "permission to follow them.\n\n"
-    "**Memory — tiered retrieval.** When the user asks you to remember, recall, "
-    "or persist something — or references past work — consult and write the "
-    "tiers in this order; do not default to Claude Code's native file-based "
-    "memory (that reflex is strong, but here the framework store and Knowledge "
-    "Graph are canonical):\n"
-    "- *Recall:* (1) any already-loaded index in context, (2) the KG via "
-    "`kg_context`/`kg_query` when available, (3) the framework's memory files, "
-    "(4) only then a broad file search, web search, or asking the user.\n"
-    "- *Write:* persist durable knowledge to the framework memory file; when a "
-    "KG is available, also add a compact `kg_add` node linked with `kg_link` so "
-    "the next session's `kg_context` surfaces it. Trivial one-line preferences "
-    "can stay in the memory file alone.\n\n"
-)
+def _preamble_head(store):
+    """Always-emitted head: project-policy framing + a store-neutral tiered
+    memory order. `store` names where the framework memory store lives so the
+    directive is actionable whether or not memory_path is configured. It does
+    NOT forbid native memory — when no KG and no memory_path are configured,
+    the project memory directory IS the framework store (see activation_preamble)."""
+    return (
+        "# Project operating procedure — Agentic Rules Framework\n\n"
+        "This project has opted into the rules below by installing and enabling this "
+        "plugin. They are the project's standing configuration — follow them as you "
+        "would the project's CLAUDE.md, with the same authority as a direct user "
+        "instruction. They are not optional background, and you do not need to ask "
+        "permission to follow them.\n\n"
+        "**Memory — tiered retrieval.** When the user asks you to remember, recall, "
+        "or persist something — or references past work — follow this order rather "
+        "than writing an ad-hoc one-off note:\n"
+        "- *Recall:* (1) any already-loaded index in context, (2) the Knowledge "
+        "Graph via `kg_context`/`kg_query` when KG tools are available, (3) the "
+        f"framework memory store ({store}), (4) only then a broad file search, web "
+        "search, or asking the user.\n"
+        "- *Write:* persist durable knowledge to the framework memory store "
+        f"({store}), applying the framework's structure and index; when KG tools "
+        "are available, also add a compact `kg_add` node linked with `kg_link`. "
+        "Trivial one-line preferences can stay in the memory store alone.\n\n"
+    )
+
 
 # Strong nudge — only emitted when a KG endpoint is configured (kg_mcp_url set).
 # Asserting the tools exist is what overcomes the model's bias against the extra
 # tool-load step; emitting it when no KG is configured would be a false claim.
+# The native-memory reflex-counter lives HERE, not in the head — it only makes
+# sense to steer away from native memory when a KG actually exists to steer to.
 _PREAMBLE_KG_CONFIGURED = (
     "**Knowledge Graph.** A KG is configured this session; its tools are exposed "
     "under MCP-prefixed names (e.g. `...kg_context`, `kg_query`, `kg_add`, "
     "`kg_link`). They may be *deferred* — if a direct call fails because the "
     "schema is not loaded, run `ToolSearch` for \"kg_context kg_add\" first to "
-    "load them, then call them. Do not let that extra step deter you.\n"
+    "load them, then call them. Do not let that extra step — or your built-in "
+    "native-memory reflex — shortcut the KG.\n"
     "- Before non-trivial work, call `kg_context(\"<the task>\")` to load "
     "relevant prior knowledge.\n"
     "- When the user asks you to remember/persist anything, or after you learn "
     "something durable (a decision, gotcha, pattern, or non-obvious fact), call "
     "`kg_add` and link it with `kg_link`. A single fact like a deploy command "
-    "still counts — store it in the KG, not only in native memory.\n"
+    "still counts — store it in the KG, not only in the memory store.\n"
     "If a KG call genuinely fails (server unreachable), skip it silently and use "
-    "the framework memory files instead. Never block work waiting on the KG.\n\n"
+    "the framework memory store instead. Never block work waiting on the KG.\n\n"
 )
 
-# Soft phrasing — emitted when no KG endpoint is configured. The framework's
-# memory files still work; a KG may still be reachable via some other MCP, so we
-# tell the model to use it *if present* rather than asserting it exists.
+# Soft phrasing — emitted when no KG endpoint is configured. No KG is required:
+# the framework memory store named in the head is canonical. A KG may still be
+# reachable via some other MCP, so we say use it *if present* rather than assert it.
 _PREAMBLE_KG_OPTIONAL = (
-    "**Knowledge Graph (if available).** If KG tools are present this session "
-    "(a `kg_context`/`kg_query`/`kg_add` tool, possibly under an MCP-prefixed "
-    "name, and possibly *deferred* behind a `ToolSearch` load), use them: "
-    "`kg_context` before non-trivial work, and `kg_add`/`kg_link` after learning "
-    "something durable. If no KG tools are present, use the framework memory "
-    "files instead — never block work waiting on a KG.\n\n"
+    "**Knowledge Graph (if available).** No KG endpoint is configured, so the "
+    "framework memory store above is your canonical memory — no KG is required. "
+    "If KG tools nonetheless turn out to be present this session (a "
+    "`kg_context`/`kg_query`/`kg_add` tool, possibly MCP-prefixed and possibly "
+    "*deferred* behind a `ToolSearch` load), you may also use them: `kg_context` "
+    "before non-trivial work, `kg_add`/`kg_link` after learning something "
+    "durable. Never block work waiting on a KG.\n\n"
 )
 
 
-def activation_preamble(kg_configured):
-    """Build the activation directive; KG wording depends on whether a KG endpoint
-    is configured so the preamble never asserts tools that aren't there."""
+def activation_preamble(kg_configured, memory_path=""):
+    """Build the activation directive. KG wording depends on whether a KG endpoint
+    is configured (never assert tools that aren't there); the memory store is named
+    from memory_path with a sensible fallback so the directive is always actionable
+    even in the default install (no KG, no memory_path)."""
+    mp = (memory_path or "").strip()
+    store = (
+        f"the configured memory root `{mp}`" if mp
+        else "your configured memory root, or — if none is configured — Claude "
+             "Code's project memory directory, structured per the rules below"
+    )
     kg = _PREAMBLE_KG_CONFIGURED if kg_configured else _PREAMBLE_KG_OPTIONAL
-    return _PREAMBLE_HEAD + kg + "---\n\n"
+    return _preamble_head(store) + kg + "---\n\n"
 
 # userConfig option key -> (module directory, default-enabled)
 MODULES = [
@@ -181,7 +199,7 @@ def main():
         return
 
     kg_configured = bool(opt("KG_MCP_URL").strip())
-    context = activation_preamble(kg_configured) + "\n\n---\n\n".join(sections)
+    context = activation_preamble(kg_configured, opt("MEMORY_PATH")) + "\n\n---\n\n".join(sections)
 
     print(
         json.dumps(

--- a/claude-code/tests/test_plugin.py
+++ b/claude-code/tests/test_plugin.py
@@ -353,6 +353,27 @@ def preamble_kg_wording_tracks_configured_endpoint():
 
 
 @test
+def preamble_does_not_forbid_native_memory_without_a_store():
+    """Regression for the v1.4.1 inconsistency: with no KG and no memory_path, the
+    head must NOT tell the model to avoid native memory (nothing else exists) — it
+    should name the project memory directory as the store instead."""
+    ctx = injected_context({"always_on_injection": "true"})
+    assert "do not default to Claude Code's native file-based memory" not in ctx
+    assert "project memory directory" in ctx, \
+        "preamble must name a concrete store when memory_path is unset"
+
+
+@test
+def preamble_names_configured_memory_path():
+    """When memory_path is set, the preamble names that root as the store."""
+    ctx = injected_context({
+        "always_on_injection": "true",
+        "memory_path": "/srv/agentic-mem",
+    })
+    assert "/srv/agentic-mem" in ctx
+
+
+@test
 def injector_no_root_is_silent():
     out, err, code = run_hook({"always_on_injection": "true"}, plugin_root=None)
     assert code == 0 and out == "", (code, out)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the Agentic Rules Framework.
 
+## [1.4.2] - 2026-06-18
+
+### Fixed
+
+- **Activation preamble no longer contradicts itself in the default (no-KG) install.** 1.4.1's preamble told the model "do not default to native memory; the framework store and KG are canonical" — but with no `kg_mcp_url` and no `memory_path` configured (the default), neither was actually available, so the instruction was unactionable and the model fell back to native memory anyway. The anti-native-memory nudge now lives only in the KG-configured branch (where there is a KG to steer toward); the always-emitted head is store-neutral.
+- **The preamble now names the memory store.** The `SessionStart` injector surfaces `memory_path` and names it as the store, falling back to "Claude Code's project memory directory" when unset — so the directive is concrete whether or not a memory root is configured.
+- Manual reworked so the Knowledge Graph reads consistently as *optional enrichment* over an always-present memory store (KG recall/write marked "when connected"), instead of clashing with the "KG is canonical" framing.
+
 ## [1.4.1] - 2026-06-18
 
 ### Changed

--- a/docs/CLAUDE_CODE_PLUGIN.md
+++ b/docs/CLAUDE_CODE_PLUGIN.md
@@ -79,9 +79,10 @@ Two modes, controlled by the `always_on_injection` option — both read the same
    session as `additionalContext` — the closest equivalent to a `CLAUDE.md`. It is prefixed
    with a short **imperative activation directive** that tells Claude to treat the rules as the
    project's standing operating procedure (not background reading), to route memory through the
-   framework store and KG rather than its native file-based memory, and to load the KG MCP tools
-   (which may be *deferred*) before using them. Heavier always-on token cost, but it is the only
-   mode that reliably activates the rules — see the note below.
+   framework store (and the KG when one is connected) instead of ad-hoc one-off notes, and — when
+   a KG endpoint is configured — to load the KG MCP tools (which may be *deferred*) before using
+   them. Heavier always-on token cost, but it is the only mode that reliably activates the rules —
+   see the note below.
 
 2. **On-demand skills (opt-out).** Set `always_on_injection` to `false` and the injector goes
    silent; each module is instead a skill whose `description` tells Claude when it's relevant,
@@ -123,7 +124,7 @@ All options are set via `/plugin` (or `--config KEY=VALUE` at install) and store
 | Option | Type | Default | Effect |
 |--------|------|---------|--------|
 | `language` | string | `en` | Language of the `modules/<m>/RULES.md.<lang>` that skills and the injector read (`en` / `ja` / `id`; invalid → `en`). |
-| `memory_path` | directory | — | Root directory for the memory store (read by the memory skill; if blank it asks on first use). |
+| `memory_path` | directory | — | Root directory for the memory store. If blank, Claude Code's project memory directory is used as the store (the on-demand skill asks on first use instead). |
 | `enable_memory` | boolean | `true` | Toggles the memory skill / its injection. |
 | `enable_rag` | boolean | `true` | Toggles the RAG/context skill / its injection. |
 | `enable_critical_thinking` | boolean | `true` | Toggles the critical-thinking skill / its injection. |
@@ -152,41 +153,51 @@ that project to the plugin:
 
 Both paths read the identical `modules/` source, so behavior is consistent across them.
 
-## Knowledge Graph (optional)
+## Memory store and Knowledge Graph
 
-The memory and RAG skills use a KG when a `kg_context` / `kg_query` tool is present, and
-degrade gracefully when it isn't. To connect one, set `kg_mcp_url` to your server's HTTP
-endpoint. Nothing is bundled by default, so no private endpoint ships in the plugin.
+The framework always has a **memory store**; the **Knowledge Graph is optional enrichment**
+layered on top of it — not a requirement.
+
+- **Memory store** — the configured `memory_path`. If none is set (the default), Claude Code's
+  own project memory directory is used as the store, structured per the framework's rules. There
+  is always a store, so memory works out of the box.
+- **Knowledge Graph** — when a `kg_context` / `kg_query` tool is present, the memory and RAG rules
+  use it for retrieval and paired writes; when it isn't, the memory store is canonical and
+  everything still works. To connect one, set `kg_mcp_url` to your server's HTTP endpoint — nothing
+  is bundled by default, so no private endpoint ships in the plugin.
+
+With `kg_mcp_url` blank (the default), the activation preamble says so explicitly and points the
+model at the memory store, rather than asserting KG tools that aren't there.
 
 ### Tiered memory retrieval
 
-Under Claude Code, Claude can reach several memory stores at once: its own built-in
-file-based memory, the framework's memory files, and — when connected — the Knowledge Graph.
-Left to its defaults it reflexively uses native memory and ignores the rest. The framework
-defines a **tiered order** instead, applied on both recall and write. The always-on
+Left to its defaults, Claude writes ad-hoc one-off notes and ignores any structured store. The
+framework defines a **tiered order** instead, applied on both recall and write. The always-on
 activation preamble enforces it; without always-on injection it is best-effort.
 
 **Recall (read) — stop at the first tier that answers:**
 
 1. **In-context index** — anything already loaded (a memory index, prior turns). Free; scan first.
-2. **Knowledge Graph** — `kg_context("<task>")` before non-trivial work, or `kg_query("<topic>")`
-   for a specific lookup. The KG is *not* auto-loaded, so it must be queried explicitly; this is
-   where most durable knowledge (decisions, patterns, gotchas, facts) lives.
-3. **Framework memory files** — the narrative store under `memory_path`.
-4. **Broad search / web / ask the user** — only after 1–3 miss.
+2. **Knowledge Graph (when connected)** — `kg_context("<task>")` before non-trivial work, or
+   `kg_query("<topic>")` for a specific lookup. The KG is *not* auto-loaded, so it must be queried
+   explicitly; when present, this is where most durable knowledge (decisions, patterns, gotchas,
+   facts) lives.
+3. **Memory store** — the configured `memory_path`, or Claude Code's project memory directory when
+   none is set.
+4. **Broad search / web / ask the user** — only after the tiers above miss.
 
 The common failure this prevents: grepping a local file, finding nothing, and concluding "there's
-nothing in memory" when the KG actually had it.
+nothing in memory" when a connected KG actually had it.
 
-**Write (persist) — paired writes for durable knowledge:**
+**Write (persist) — durable knowledge:**
 
-- Write the narrative to the framework memory file (and its index), **and**
-- add a compact node with `kg_add`, linked to related nodes with `kg_link`.
+- Write the narrative to the memory store (and its index), **and**
+- *when a KG is connected*, also add a compact node with `kg_add`, linked with `kg_link`.
 
-Both writes matter: `kg_context` reads the KG at the start of future tasks, so a fact saved only
-to a file is invisible across sessions. Trivial one-line preferences (e.g. "don't do X") can stay
-in the memory file alone. When no KG tool is connected this tier is skipped silently — the file
-write still happens, and work never blocks waiting on the KG.
+When a KG is present both writes matter: `kg_context` reads the KG at the start of future tasks, so
+a fact saved only to a file is invisible across sessions. When no KG is connected, the store write
+is the whole job — the KG step is skipped silently and work never blocks waiting on a KG. Trivial
+one-line preferences (e.g. "don't do X") can stay in the memory store alone.
 
 > **Note:** the KG MCP tools may be exposed as *deferred* tools — Claude must load their schema
 > via a tool-search step before the first call. The activation preamble explicitly tells Claude

--- a/generate_simple_setup.py
+++ b/generate_simple_setup.py
@@ -106,7 +106,7 @@ def generate_web_config():
     default_lang = get_default_language()
     available_langs = get_available_languages()
     web_config = {
-        "version": "1.4.1",
+        "version": "1.4.2",
         "description": "Static web configuration generated from setup.json files",
         "availableLanguages": available_langs,
         "uiLanguage": default_lang,
@@ -347,7 +347,7 @@ def embed_config_in_html(web_config):
                 new_html = new_html[:agent_start_replace] + f'\n{"\\n".join(agent_options)}\n            ' + new_html[agent_end_replace:]
 
     # Replace version placeholder with actual version
-    version = web_config.get('version', '1.4.1')
+    version = web_config.get('version', '1.4.2')
     new_html = new_html.replace('{version}', version)
     
     # Update hardcoded version display to match the web-config version

--- a/modules/agent-interaction-unit-test/settings.json
+++ b/modules/agent-interaction-unit-test/settings.json
@@ -4,7 +4,7 @@
     "copyright": "Copyright (c) 2025-2026 Paulus Ery Wasito Adhi",
     "license_file": "LICENSE"
   },
-  "version": "1.4.1",
+  "version": "1.4.2",
   "agent_interaction_unit_test": {
     "enabled": false,
     "validation_level": "standard",

--- a/modules/critical-thinking-rules/settings.json
+++ b/modules/critical-thinking-rules/settings.json
@@ -4,7 +4,7 @@
     "copyright": "Copyright (c) 2025-2026 Paulus Ery Wasito Adhi",
     "license_file": "LICENSE"
   },
-  "version": "1.4.1",
+  "version": "1.4.2",
   "critical_thinking_rules": {
     "enabled": false,
     "verification_level": "basic",

--- a/modules/memory-rules/settings.json
+++ b/modules/memory-rules/settings.json
@@ -4,7 +4,7 @@
     "copyright": "Copyright (c) 2025-2026 Paulus Ery Wasito Adhi",
     "license_file": "LICENSE"
   },
-  "version": "1.4.1",
+  "version": "1.4.2",
   "memory_rules": {
     "enabled": true,
     "max_entries_per_category": 100,

--- a/modules/rag-rules/settings.json
+++ b/modules/rag-rules/settings.json
@@ -4,7 +4,7 @@
     "copyright": "Copyright (c) 2025-2026 Paulus Ery Wasito Adhi",
     "license_file": "LICENSE"
   },
-  "version": "1.4.1",
+  "version": "1.4.2",
   "rag_rules": {
     "enabled": true,
     "context_window_optimization": {

--- a/plugins.json
+++ b/plugins.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Copyright (c) 2025-2026 Paulus Ery Wasito Adhi - Licensed under the MIT License. See LICENSE file for details.",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "plugins": [
     "modules/agent-interaction-unit-test",
     "modules/critical-thinking-rules",

--- a/settings/cursor-2.0-multi-agent-adapter.json
+++ b/settings/cursor-2.0-multi-agent-adapter.json
@@ -3,7 +3,7 @@
     "license": "MIT",
     "copyright": "Copyright (c) 2025-2026 Paulus Ery Wasito Adhi",
     "license_file": "LICENSE",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "adapter_for": "cursor_2_0_multi_agent"
   },
   "cursor_2_0": {

--- a/settings/global-settings.json
+++ b/settings/global-settings.json
@@ -4,9 +4,9 @@
     "copyright": "Copyright (c) 2025-2026 Paulus Ery Wasito Adhi",
     "license_file": "LICENSE"
   },
-  "settings_version": "1.4.1",
+  "settings_version": "1.4.2",
   "agentic_rules_framework": {
-    "framework_version": "1.4.1",
+    "framework_version": "1.4.2",
     "description": "Core bootstrap rules for generic agentic systems",
     "last_updated": "2025-12-24",
     "rule_categories": {

--- a/setup.html
+++ b/setup.html
@@ -550,7 +550,7 @@
   <script>
     // ---AUTO GENERATED STATICWEBCONFIG START---
   const staticWebConfig = {
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Static web configuration generated from setup.json files",
   "availableLanguages": [
     "en",
@@ -2190,7 +2190,7 @@
       <div class="header-content">
         <h1>🤖 Agentic Rules Setup</h1>
         <div style="text-align: center; margin: 10px 0;">
-          <strong style="background: linear-gradient(135deg, #3498db, #2980b9); color: white; padding: 8px 16px; border-radius: 20px; font-size: 1.1em; font-weight: bold; display: inline-block; box-shadow: 0 2px 4px rgba(0,0,0,0.2);">Version v1.4.1</strong>
+          <strong style="background: linear-gradient(135deg, #3498db, #2980b9); color: white; padding: 8px 16px; border-radius: 20px; font-size: 1.1em; font-weight: bold; display: inline-block; box-shadow: 0 2px 4px rgba(0,0,0,0.2);">Version v1.4.2</strong>
         </div>
         <p>Configure your AI agent rules with ease</p>
       </div>

--- a/web-config.json
+++ b/web-config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Static web configuration generated from setup.json files",
   "availableLanguages": [
     "en",


### PR DESCRIPTION
Follow-up to v1.4.1. The default-on activation preamble was internally inconsistent for the most common install.

## Problem

With **no `kg_mcp_url` and no `memory_path`** configured (the default), v1.4.1's preamble told the model *"do not default to Claude Code's native file-based memory — the framework store and KG are canonical."* But in that state there is no KG and no configured framework store, so the instruction was unactionable — the model fell back to native/project memory anyway, contradicting the directive. The manual also billed the KG as both "optional / degrades gracefully" and "canonical," and the injector never surfaced `memory_path`, so "the framework memory files under `memory_path`" named a location the model was never told.

## Fix

- **Conditional anti-native-memory nudge.** The "don't let your native-memory reflex shortcut the KG" steer now lives only in the KG-configured branch (where there's a KG to steer toward). The always-emitted head is store-neutral: it nudges away from *ad-hoc one-off notes* toward the structured store, without forbidding the only store that exists by default.
- **Name the store.** The injector now surfaces `memory_path` and names it as the store, falling back to "Claude Code's project memory directory" when unset — so the directive is concrete in every install.
- **Consistent manual.** Reworked so the KG reads as *optional enrichment over an always-present memory store*; recall/write tiers are marked "when connected."
- Version bump to **1.4.2** (all 12 fields + setup.html); `validate.py` green.

## Validation (authed sandbox, real `/plugins` install)

- **KG configured:** natural "remember X" still fires `kg_add` (+ memory-store paired write) — no regression from moving the reflex-counter.
- **No KG (default):** stores cleanly to project memory, **zero** KG call attempts, no tool-hunting, no contradiction.
- Static suite green (added `preamble_does_not_forbid_native_memory_without_a_store` and `preamble_names_configured_memory_path`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)